### PR TITLE
fixed typos

### DIFF
--- a/API_DOCUMENTATION_EN.md
+++ b/API_DOCUMENTATION_EN.md
@@ -726,7 +726,7 @@ Returns information about internal calls
 | time | string `YYYY-MM-DD HH:ii:ss` | Time of the block that contains the call (UTC) | + | + |
 | failed | bool | Failed call or not | + | |
 | fail_reason | string `.*` or null | If failed, then the failure description, if not, then `null` | + | |
-| type | string (enum) | The call type, one of the following values: `call/delegatecall/staticcall/callcode/selfdesctruct/create/synthetic_coinbase` | + | |
+| type | string (enum) | The call type, one of the following values: `call/delegatecall/staticcall/callcode/selfdestruct/create/synthetic_coinbase` | + | |
 | sender (\*\*) | string `0x[0-9a-f]{40}` | Sender's address (with 0x) | + | |
 | recipient | string `0x[0-9a-f]{40}` | Recipient's address (with 0x) | + | |
 | child_call_count | int | Number of child calls | + | + |

--- a/API_DOCUMENTATION_RU.md
+++ b/API_DOCUMENTATION_RU.md
@@ -515,7 +515,7 @@ It is expected that Dogecoin will be out of beta mode very soon. Wow.
 | time | string `YYYY-MM-DD HH:ii:ss` | Время блока, в котором содержится колл (UTC) | + | + |
 | failed | bool | Не зафейлился ли колл | + | |
 | fail_reason | string `.*` или null  | Если зафейлился, то строка с причиной, если нет, то `null` | + | |
-| type | string (enum) | Тип колла - одно из следующих значений: `call/delegatecall/staticcall/callcode/selfdesctruct/create/synthetic_coinbase` | + | |
+| type | string (enum) | Тип колла - одно из следующих значений: `call/delegatecall/staticcall/callcode/selfdestruct/create/synthetic_coinbase` | + | |
 | sender(\*\*) | string `0x[0-9a-f]{40}` | Адрес вызывающего колл (с 0x) | + | |
 | recipient | string `0x[0-9a-f]{40}` | Адрес вызываемого коллом (с 0x) | + | |
 | child_call_count | int | Количество дочерних коллов | + | + |


### PR DESCRIPTION
There is a small typo in the `type` enum documentation. This pull request fixes that.

Best regards
Matthias